### PR TITLE
:sparkles: Add InteractableBehaviour component to enable interaction with GameObjects

### DIFF
--- a/2022_3DGED_GDApp/App/Main.cs
+++ b/2022_3DGED_GDApp/App/Main.cs
@@ -117,7 +117,7 @@ namespace GD.App
             InitializeDrawnContent(worldScale);
 
             //add the player
-            InitializePlayer();
+            //InitializePlayer();
         }
 
         private void SetTitle(string title)
@@ -297,7 +297,9 @@ namespace GD.App
             InitializeDemoQuad();
 
             //load an FBX and draw
-            InitializeDemoModel();
+            //InitializeDemoModel();
+
+            TestingInteractableItem();
         }
 
         private void InitializeDemoModel()
@@ -317,6 +319,23 @@ namespace GD.App
 
             //lets try out our CycleTranslationBehaviour
             // gameObject.AddComponent(new CycledTranslationBehaviour(0.1f, 10));
+
+            sceneManager.ActiveScene.Add(gameObject);
+        }
+
+        private void TestingInteractableItem()
+        {
+            var gameObject = new GameObject("interactable", ObjectType.Static, RenderType.Opaque);
+            gameObject.Transform = new Transform(0.7f * Vector3.One, null, new Vector3(0, 2, 1));
+            var texture = Content.Load<Texture2D>("Assets/Textures/Props/Crates/crate2");
+
+            var model = Content.Load<Model>("Assets/Models/sphere");
+
+            var mesh = new Engine.ModelMesh(_graphics.GraphicsDevice, model);
+            gameObject.AddComponent(new Renderer(new GDBasicEffect(effect),
+                new Material(texture, 1),
+                mesh));
+            gameObject.AddComponent(new InteractableBehaviour());
 
             sceneManager.ActiveScene.Add(gameObject);
         }

--- a/2022_3DGED_GDEngine/2022_3DGED_GDEngine.projitems
+++ b/2022_3DGED_GDEngine/2022_3DGED_GDEngine.projitems
@@ -15,6 +15,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Core\Components\3D\Base\Transform.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Components\3D\Behaviours\CurveBehaviour.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Components\3D\Behaviours\CycledTranslationBehaviour.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core\Components\3D\Behaviours\InteractableBehaviour.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Components\3D\Behaviours\SimpleRotationBehaviour.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Components\3D\Behaviours\CycledRotationBehaviour.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Components\3D\Camera\Camera.cs" />
@@ -48,6 +49,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Core\Inputs\GamepadComponent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Inputs\KeyboardComponent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Inputs\MouseComponent.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core\Managers\RenderManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Types\Integer2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Managers\CameraManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Managers\SceneManager.cs" />

--- a/2022_3DGED_GDEngine/Core/Components/3D/Behaviours/InteractableBehaviour.cs
+++ b/2022_3DGED_GDEngine/Core/Components/3D/Behaviours/InteractableBehaviour.cs
@@ -1,0 +1,60 @@
+﻿using GD.Engine.Globals;
+using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
+using System.Drawing.Text;
+using System.Text;
+
+namespace GD.Engine
+{
+    public class InteractableBehaviour : Component
+    {
+        private GameObject target;
+        private FirstPersonController controller;
+
+        public InteractableBehaviour()
+        {
+        }
+
+        public override void Update(GameTime gameTime)
+        {
+            if (target == null || target != Application.CameraManager.ActiveCamera.gameObject)
+            {
+                target = Application.CameraManager.ActiveCamera.gameObject;
+            }
+            controller = target.GetComponent<FirstPersonController>();
+
+            //System.Diagnostics.Debug.WriteLine($"Target: {target.Name}");
+
+            float targetDist = GetDistance();
+            System.Diagnostics.Debug.WriteLine($"Distance: {targetDist}");
+
+            CheckTrigger();
+
+            //base.Update(gameTime);
+        }
+
+        public float GetDistance()
+        {
+            float distance = Vector3.Distance(target.Transform.translation, transform.translation);
+            return distance;
+        }
+
+        public void CheckTrigger()
+        {
+            if (controller == null)
+            {
+                System.Diagnostics.Debug.WriteLine("Controller not found");
+                return;
+            }
+            bool isInteracting = controller.IsInteracting;
+
+            float targetDist = GetDistance();
+
+            if (isInteracting && targetDist < 3f)
+            {
+                System.Diagnostics.Debug.WriteLine("Picked Up");
+            }
+        }
+    }
+}

--- a/2022_3DGED_GDEngine/Core/Components/3D/Controllers/Camera/FirstPersonController.cs
+++ b/2022_3DGED_GDEngine/Core/Components/3D/Controllers/Camera/FirstPersonController.cs
@@ -2,6 +2,7 @@
 using GD.Engine.Globals;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
+using System;
 
 namespace GD.Engine
 {
@@ -20,7 +21,14 @@ namespace GD.Engine
         private bool crouchEnabled = false;
         private bool needsToCrouch = true;
 
+        private bool isInteracting = false;
+
         #endregion Fields
+
+        public bool IsInteracting
+        {
+            get => isInteracting;
+        }
 
         #region Temps
 
@@ -52,10 +60,14 @@ namespace GD.Engine
         {
             HandleMouseInput(gameTime);
             HandleKeyboardInput(gameTime);
+            System.Diagnostics.Debug.WriteLine($"crouchEnabled: {crouchEnabled}");
+            System.Diagnostics.Debug.WriteLine($"needsToCrouch: {needsToCrouch}");
         }
 
         protected virtual void HandleKeyboardInput(GameTime gameTime)
         {
+            CheckInteracting();
+
             float runMultiplier = 2.5f;
 
             translation = Vector3.Zero;
@@ -129,6 +141,16 @@ namespace GD.Engine
                 needsToCrouch = false;
                 multiplier = 1f;
             }
+        }
+
+        protected virtual void CheckInteracting()
+        {
+            if (Input.Keys.IsPressed(Keys.E))
+            {
+                isInteracting = true;
+            }
+            else
+                isInteracting = false;
         }
 
         protected virtual void HandleMouseInput(GameTime gameTime)

--- a/2022_3DGED_GDEngine/Core/Managers/RenderManager.cs
+++ b/2022_3DGED_GDEngine/Core/Managers/RenderManager.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.Xna.Framework;
+
+namespace GD.Engine.Managers
+{
+    /// <summary>
+    /// Performs draw (or render) on ActiveScene objects
+    /// </summary>
+    public class RenderManager // : DrawableGameComponent
+    {
+    }
+}


### PR DESCRIPTION
Uses the 'E' key to interact with objects once the First-Person Camera is within 3 units distance of the object.